### PR TITLE
docs: add mcp-get installation instructions and improve section organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,23 +28,6 @@ Prompts are for users to include in chat history, i.e. via `Zed`'s slash command
 
 - `run_command` - generate a prompt message with the command output
 
-## Development
-
-Install dependencies:
-```bash
-npm install
-```
-
-Build the server:
-```bash
-npm run build
-```
-
-For development with auto-rebuild:
-```bash
-npm run watch
-```
-
 ## Installation
 
 There are two ways to install mcp-server-commands. Using mcp-get provides a one-step installation:
@@ -105,3 +88,20 @@ npm run inspector
 ```
 
 The Inspector will provide a URL to access debugging tools in your browser.
+
+## Development
+
+Install dependencies:
+```bash
+npm install
+```
+
+Build the server:
+```bash
+npm run build
+```
+
+For development with auto-rebuild:
+```bash
+npm run watch
+```

--- a/README.md
+++ b/README.md
@@ -79,16 +79,6 @@ If you want to see more messages, add `--verbose` to the `args` when configuring
 By the way, logs are written to `STDERR` because that is what Claude Desktop routes to the log files.
 In the future, I expect well formatted log messages to be written over the `STDIO` transport to the MCP client (note: not Claude Desktop app).
 
-### Debugging
-
-Since MCP servers communicate over stdio, debugging can be challenging. We recommend using the [MCP Inspector](https://github.com/modelcontextprotocol/inspector), which is available as a package script:
-
-```bash
-npm run inspector
-```
-
-The Inspector will provide a URL to access debugging tools in your browser.
-
 ## Development
 
 Install dependencies:
@@ -105,3 +95,13 @@ For development with auto-rebuild:
 ```bash
 npm run watch
 ```
+
+### Debugging
+
+Since MCP servers communicate over stdio, debugging can be challenging. We recommend using the [MCP Inspector](https://github.com/modelcontextprotocol/inspector), which is available as a package script:
+
+```bash
+npm run inspector
+```
+
+The Inspector will provide a URL to access debugging tools in your browser.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ npm run watch
 
 ## Installation
 
+There are two ways to install mcp-server-commands. Using mcp-get provides a one-step installation:
+
+```bash
+npx @michaellatman/mcp-get@latest install mcp-server-commands
+```
+
+### Using npm directly
+
 To use with Claude Desktop, add the server config:
 
 On MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`


### PR DESCRIPTION
This PR adds mcp-get installation instructions and improves the README organization:

- Added mcp-get one-step installation instructions
- Moved Installation section above Development section
- Moved Development section before Debugging section

Note: This PR was generated via automation.

Link to Devin run: https://app.devin.ai/sessions/1e474c7379014208a51ff7006f6d2165