### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Published to npm as [mcp-server-commands](https://www.npmjs.com/package/mcp-serv
 > Permissions are dictated by the user that runs the server.
 > DO NOT run with `sudo`.
 
+<a href="https://glama.ai/mcp/servers/4vlwa2czqa"><img width="380" height="200" src="https://glama.ai/mcp/servers/4vlwa2czqa/badge" alt="mcp-server-commands MCP server" /></a>
+
 ## Tools
 
 Tools are for LLMs to request, i.e. Claude Desktop app. Claude Sonnet 3.5 intelligently uses both tools, I was pleasantly surprised.


### PR DESCRIPTION
This PR adds a badge for the mcp-server-commands server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/4vlwa2czqa"><img width="380" height="200" src="https://glama.ai/mcp/servers/4vlwa2czqa/badge" alt="mcp-server-commands MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.