### PR TITLE
docs: update local build instructions to use node directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,20 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 {
   "mcpServers": {
     "mcp-server-commands": {
-      // works b/c of shebang in index.js
-      "command": "/path/to/mcp-server-commands/build/index.js"
+      "command": "node",
+      "args": [
+        "/path/to/mcp-server-commands/build/index.js",
+        "--verbose"
+      ],
+      "env": {
+        "NODE_PATH": "/path/to/mcp-server-commands/node_modules"
+      }
     }
   }
 }
 ```
+
+Note: Replace `/path/to/mcp-server-commands` with your actual path to the repository.
 
 ### Logging
 


### PR DESCRIPTION
Updated the README.md to show the correct way to configure the server for local builds:
- Changed to use node command directly instead of relying on shebang
- Added NODE_PATH env var to ensure dependencies are found
- Added --verbose flag for better debugging
- Added note about path replacement