### PR TITLE
fix: invalid type error (missing required 'content' prop)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -164,12 +164,12 @@ server.setRequestHandler(
         switch (request.params.name) {
             case "run_command": {
                 return {
-                    toolResult: await runCommand(request.params.arguments),
+                    ...(await runCommand(request.params.arguments)),
                 };
             }
             case "run_script": {
                 return {
-                    toolResult: await runScript(request.params.arguments),
+                    ...(await runScript(request.params.arguments)),
                 };
             }
             default:


### PR DESCRIPTION
# Error Description
```
Error executing MCP tool:
[
  {
    "code": "invalid_type",
    "expected": "array",
    "received": "undefined",
    "path": [
      "content"
    ],
    "message": "Required"
  }
]
```
Occurs to any run_command

# Solution:
directly return the results of `runCommand` which has the structure { content: [messages] }