### PR TITLE
feat: add MCP tool annotations to run_command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mcp-server-commands",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mcp-server-commands",
-            "version": "0.5.0",
+            "version": "0.6.0",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "1.9.0"
             },

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -41,6 +41,11 @@ export function reisterTools(server: Server) {
                         },
                         required: ["command"],
                     },
+                    annotations: {
+                        title: "Run Command",
+                        destructiveHint: true,
+                        openWorldHint: true,
+                    },
                 },
             ],
         };


### PR DESCRIPTION
## Summary

Add MCP tool annotations to the `run_command` tool to improve AI assistant understanding of tool behavior:

- `destructiveHint: true` - Commands can modify or delete files on the system
- `openWorldHint: true` - Tool interacts with the external system shell

## Background

MCP tool annotations (introduced in SDK 1.7.0) help AI assistants make better decisions about tool usage and provide appropriate user confirmations. Since this server already uses SDK 1.9.0, no version bump was needed.

## Changes

- Added `annotations` block to the `run_command` tool definition in `src/tools.ts`

## Testing

- ✅ TypeScript compilation passes
- ✅ No breaking changes to existing functionality

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)