### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ For development with auto-rebuild:
 npm run watch
 ```
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/g0t4-mcp-server-commands).
+
 ## Installation
 
 To use with Claude Desktop, add the server config:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/g0t4-mcp-server-commands).